### PR TITLE
Fixed a NPE in MobiusCore

### DIFF
--- a/src/main/java/mcp/mobius/mobiuscore/monitors/MonitoredEntityList.java
+++ b/src/main/java/mcp/mobius/mobiuscore/monitors/MonitoredEntityList.java
@@ -31,7 +31,7 @@ public class MonitoredEntityList<E> extends MonitoredList<E>{
 	
 	@Override
 	protected void removeCount(Object o){
-		if (o == null) return;
+		if (!(o instanceof E)) return;
 		String name = this.getName(o);
 		
 		try{

--- a/src/main/java/mcp/mobius/mobiuscore/monitors/MonitoredEntityList.java
+++ b/src/main/java/mcp/mobius/mobiuscore/monitors/MonitoredEntityList.java
@@ -48,7 +48,7 @@ public class MonitoredEntityList<E> extends MonitoredList<E>{
 
 	protected String getName(Object o){
 		try {
-			return ((Entity) o).getCommandSenderName()
+			return ((Entity) o).getCommandSenderName();
 		}
 		catch (ClassCastException|NullPointerException suppressed) {
 			return "<bad object>";

--- a/src/main/java/mcp/mobius/mobiuscore/monitors/MonitoredEntityList.java
+++ b/src/main/java/mcp/mobius/mobiuscore/monitors/MonitoredEntityList.java
@@ -44,11 +44,15 @@ public class MonitoredEntityList<E> extends MonitoredList<E>{
 	@Override
 	protected void clearCount(){
 		this.count.clear();
-	}	
-	
+	}
+
 	protected String getName(Object o){
-		return ((Entity)o).getCommandSenderName();
-		//return o.getClass().getName();
+		try {
+			return ((Entity) o).getCommandSenderName()
+		}
+		catch (ClassCastException|NullPointerException suppressed) {
+			return "<bad object>";
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Should address this crash:
```
java.lang.NullPointerException: Exception ticking world entities
    at net.minecraft.item.ItemStack.func_77977_a(Unknown Source)
    at net.minecraft.entity.item.EntityItem.func_70005_c_(EntityItem.java:480)
    at mcp.mobius.mobiuscore.monitors.MonitoredEntityList.getName(MonitoredEntityList.java:50)
    at mcp.mobius.mobiuscore.monitors.MonitoredEntityList.removeCount(MonitoredEntityList.java:35)
    at mcp.mobius.mobiuscore.monitors.MonitoredEntityList.removeCount(MonitoredEntityList.java:29)
    at mcp.mobius.mobiuscore.monitors.MonitoredList.remove(MonitoredList.java:50)
    at net.minecraft.world.World.func_72939_s(World.java:2514)
    at net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:673)
    at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:986)
    at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:432)
    at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:841)
    at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:693)
    at java.lang.Thread.run(Thread.java:748)
```